### PR TITLE
Fix: Do not rewrite paths to keep relative paths

### DIFF
--- a/statique.gemspec
+++ b/statique.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "front_matter_parser", "~> 1.0.1"
   spec.add_dependency "hashie", "~> 5.0.0"
   spec.add_dependency "memo_wise", "~> 1.6.0"
-  spec.add_dependency "rack-rewrite", "~> 1.5.1"
   spec.add_dependency "roda", "~> 3.52"
   spec.add_dependency "slim", "~> 4.1.0"
   spec.add_dependency "thor", "~> 1.2.1"


### PR DESCRIPTION
Assets had trouble finding the relative path because we were rewriting and changing the final path to the document.

Using the proc matcher, we can keep the path we were given and match on the split subpath to find the matching document.